### PR TITLE
hot fix : 식단 수정페이지에서 메뉴 수정 시 모든 식단이 같이 변경되는 오류

### DIFF
--- a/src/app/(sub)/mealplan/MealPlanItem.tsx
+++ b/src/app/(sub)/mealplan/MealPlanItem.tsx
@@ -139,7 +139,7 @@ const MealPlanItem = ({
         {type === "search" ? (
           <p className="text-center ">
             {MEAL_ITEM_TITLE.calory}:{" "}
-            {calcKcal(kcal, value, amount).toLocaleString()} kcal
+            {calcKcal(true, kcal, value, amount).toLocaleString()} kcal
           </p>
         ) : (
           <div className="flex items-center justify-center gap-2">

--- a/src/app/(sub)/mealplan/MealplanForm.tsx
+++ b/src/app/(sub)/mealplan/MealplanForm.tsx
@@ -45,7 +45,10 @@ export default function MealplanForm({
   const totalCalory =
     mealPlanList.length > 0 &&
     mealPlanList
-      .map((meal) => meal && calcKcal(meal.kcal, meal.value, meal.amount))
+      .map(
+        (meal) =>
+          meal && calcKcal(meal.did !== 4, meal.kcal, meal.value, meal.amount)
+      )
       .reduce((a, b) => a && b && a + b);
   const pathname = usePathname();
   const id = edit ? pathname.split("/").at(-1) : undefined;
@@ -62,7 +65,7 @@ export default function MealplanForm({
                 const value = item.did === 4 ? 0 : 100;
                 return {
                   ...item,
-                  kcal: reCalcKcal(kcal, value, item.amount),
+                  kcal: reCalcKcal(item.did !== 4, kcal, value, item.amount),
                   menu_spec: {
                     carbs: reCalcMenuSpec(
                       item.did !== 4,
@@ -127,7 +130,7 @@ export default function MealplanForm({
         }) => {
           return {
             menu,
-            kcal: calcKcal(kcal, value, amount),
+            kcal: calcKcal(did !== 4, kcal, value, amount),
             amount,
             did,
             cid,

--- a/src/app/(sub)/util.ts
+++ b/src/app/(sub)/util.ts
@@ -160,12 +160,28 @@ export function reCalcMenuSpec(
   return num;
 }
 
-export function calcKcal(kcal: number, value: number, amount: number) {
-  return value !== 0 ? toFixeNumberTwo((kcal / value) * amount) : kcal;
+export function calcKcal(
+  isSearch: boolean,
+  kcal: number,
+  value: number,
+  amount: number
+) {
+  if (isSearch) {
+    return value !== 0 ? toFixeNumberTwo((kcal / value) * amount) : kcal;
+  }
+  return kcal;
 }
 
-export function reCalcKcal(kcal: number, value: number, amount: number) {
-  return value !== 0 ? toFixeNumberTwo((kcal * value) / amount) : kcal;
+export function reCalcKcal(
+  isSearch: boolean,
+  kcal: number,
+  value: number,
+  amount: number
+) {
+  if (isSearch) {
+    return value !== 0 ? toFixeNumberTwo((kcal * value) / amount) : kcal;
+  }
+  return kcal;
 }
 
 // input fns

--- a/src/store/mealPlanStore.ts
+++ b/src/store/mealPlanStore.ts
@@ -19,12 +19,14 @@ const useMealPlanStore = create<MealPlanStoreType>((set) => ({
   setCmid: (cmid) => set({ cmid: cmid }),
   reset: () => set({ mealPlanList: [] }),
   editStart: (mealList) => {
-    const cmid = uuid();
-    const newList = mealList.map((item) => ({
-      ...item,
-      type: item.did === 4 ? ("self" as MealItemType) : "search",
-      id: cmid,
-    }));
+    const newList = mealList.map((item) => {
+      const cmid = uuid();
+      return {
+        ...item,
+        type: item.did === 4 ? ("self" as MealItemType) : "search",
+        id: cmid,
+      };
+    });
     set({ mealPlanList: newList });
   },
   addMeal: (newMeal) => {


### PR DESCRIPTION
- store의 식단 uuid 중복 문제 해결
- 칼로리 계산시 검색된 메뉴인지 아닌지 여부에 따라 계산 하도록 수정